### PR TITLE
Add ClawLens to Security & Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Each plugin follows the standard OpenClaw plugin structure (`openclaw.plugin.jso
 | [SecureClaw](https://github.com/adversa-ai/secureclaw) | adversa-ai | 274 | OWASP Agentic Security Top 10 aligned. 56 automated checks across 8 categories scanning for exposed gateway ports, weak permissions, missing auth, plaintext credentials, and disabled sandboxing. |
 | [GuardSpine](https://github.com/DNYoussef/guardspine-openclaw) | DNYoussef | — | Deny-by-default tool gating with L0–L4 risk tiers, SHA-256 hash-chained evidence packs, local 3-model council voting (Qwen/Falcon/Coder via Ollama), and Discord approval notifications. |
 | [@axonflow/openclaw](https://github.com/getaxonflow/axonflow-openclaw-plugin) | getaxonflow | — | Policy enforcement, PII detection, and audit trails for OpenClaw tool execution. Integrates with AxonFlow's governance engine for real-time input/output checks. |
+| [ClawLens](https://github.com/nk3750/clawlens) | nk3750 | — | Local-first OpenClaw plugin that sits inside the runtime, observes every tool call before execution, scores risky behavior, keeps a tamper-evident hash-chain audit trail, and turns observed actions into block, require-approval, or allow-notify guardrails delivered to Telegram. |
 
 ### Observability & Cost
 


### PR DESCRIPTION
Adds **ClawLens** to the `### Security & Governance` table (after axonflow).

**ClawLens** is a local-first OpenClaw plugin for agent observability and runtime guardrails. It sits inside the OpenClaw runtime, observes every tool call before execution, scores risky behavior, keeps a tamper-evident hash-chain audit trail, and lets operators turn observed actions into block / require-approval / allow-notify guardrails delivered to Telegram.

**Install**
```
openclaw plugins install clawhub:@nk3750/openclaw-clawlens
```

**Real catch from dogfood**: ClawLens stopped my SEO agent from trend-jacking a tragedy in the news cycle for backlinks. Screenshot available on request.

**Links**
- GitHub: https://github.com/nk3750/clawlens
- ClawHub (v1.0.1, MIT, ClawScan-passed): https://clawhub.ai/plugins/@nk3750/openclaw-clawlens
- 2-min demo: https://youtu.be/AKzhw5GWw5I

Happy to reformat the row or move to Observability & Cost if Security & Governance isn't the right fit.