### PR TITLE
Add Claw Lens to OpenClaw tools list in README observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Each plugin follows the standard OpenClaw plugin structure (`openclaw.plugin.jso
 | [openclaw-observability-plugin](https://github.com/henrikrexed/openclaw-observability-plugin) | henrikrexed | — | Full OpenTelemetry observability with connected trace hierarchy (request → agent turn → tool calls), per-tool timing, and token usage tracking. Supports Dynatrace, Grafana Cloud, and local OTLP collectors. |
 | [openclaw-observatory](https://github.com/ThisIsJeron/openclaw-observatory) | ThisIsJeron | — | Self-hosted dashboard monitoring sessions, context window usage, and costs across all gateways. |
 | [Silos Dashboard](https://github.com/cheapestinference/silos) | cheapestinference | — | Open-source (MIT) multi-tenant dashboard for OpenClaw — shared browser session, multi-channel management (WhatsApp, Telegram, Discord, Slack), skills marketplace, Docker one-command deploy, agent/session analytics, cron jobs, i18n (en/es/fr/de). Also available as [managed hosting](https://silosplatform.com). |
+| [Claw Lens](https://github.com/msfirebird/claw-lens) | msfirebird | — | Open-source local dashboard combining observability, analytics, and developer tooling for OpenClaw — cost tracking, session inspection, profiler, cache trace, and security audit. |
 
 ### Multi-Agent
 


### PR DESCRIPTION
Add claw-lens project to README observability section A local-first dashboard for OpenClaw combining observability, cost analytics, and debugging/inspection.

npm: npx claw-lens-cli

repo: https://github.com/msfirebird/claw-lens
docs: https://claw-lens.com