### PR TITLE
Add FlowBoard: local-first project management for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Each plugin follows the standard OpenClaw plugin structure (`openclaw.plugin.jso
 | [openclaw-observability-plugin](https://github.com/henrikrexed/openclaw-observability-plugin) | henrikrexed | — | Full OpenTelemetry observability with connected trace hierarchy (request → agent turn → tool calls), per-tool timing, and token usage tracking. Supports Dynatrace, Grafana Cloud, and local OTLP collectors. |
 | [openclaw-observatory](https://github.com/ThisIsJeron/openclaw-observatory) | ThisIsJeron | — | Self-hosted dashboard monitoring sessions, context window usage, and costs across all gateways. |
 | [Silos Dashboard](https://github.com/cheapestinference/silos) | cheapestinference | — | Open-source (MIT) multi-tenant dashboard for OpenClaw — shared browser session, multi-channel management (WhatsApp, Telegram, Discord, Slack), skills marketplace, Docker one-command deploy, agent/session analytics, cron jobs, i18n (en/es/fr/de). Also available as [managed hosting](https://silosplatform.com). |
+| [FlowBoard](https://github.com/rasimme/FlowBoard) | rasimme | — | Local-first project workspace for OpenClaw and external coding agents. Multi-project context with lazy loading, spec-driven development from sticky notes via Specify workflow, agent-native Kanban with multi-agent visibility, and Telegram Mini App remote access. |
 
 ### Multi-Agent
 


### PR DESCRIPTION
## What this adds

**FlowBoard** — a local-first project workspace and project-management plugin for OpenClaw, Claude Code, Codex, Cursor, and multi-agent coding workflows.

### What it does

- **Persistent multi-project context with lazy loading** — agents receive project goals, decisions, specs, rules, and current task state without re-explaining the project every session.
- **Agent-native Kanban and work states** — claims, leases, checkpoints, review gates, Working / Waiting / Blocked / Paused context, and visibility across multiple active agents.
- **Spec-driven development from rough ideas** — the Idea Canvas and Specify workflow turn notes into clarified tasks and acceptance-criteria-backed specs.
- **Local-first and self-hosted** — project data stays on the operator's machine; remote mobile access is optional.

Current release: **v5.1.0**, published on ClawHub with a clean security verdict.

Install with:

```bash
openclaw plugins install flowboard
```

### Category

Added to **Observability & Cost** alongside other project dashboards. If maintainers prefer a Productivity / Project Management category, I am happy to move it.
