### PR TITLE
Add SpraayBatch — batch USDC payment plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Each plugin follows the standard OpenClaw plugin structure (`openclaw.plugin.jso
 ### Payments & Web3
 
 - **[openclaw-crossmint-plugin](https://github.com/Crossmint/openclaw-crossmint-plugin)** — On-chain wallet and payments via Crossmint smart wallets. Agents can manage balances, send tokens, and buy products using stablecoins.
+- **[SpraayBatch](https://github.com/plagtech/SpraayBatch)** — Batch USDC payments on Base. Pay up to 200 recipients in one atomic transaction, gasless via CDP Paymaster. Non-custodial auto-wallets and per-agent budget caps. `openclaw plugins install clawhub:spraay-batch` · [ClawHub](https://clawhub.ai/plagtech/plugins/spraay-batch)
 
 ### Health & Wellness
 


### PR DESCRIPTION
Adds SpraayBatch, a batch USDC payment plugin for Base.

- **Repo**: https://github.com/plagtech/SpraayBatch
- **ClawHub**: https://clawhub.ai/plagtech/plugins/spraay-batch
- **Install**: `openclaw plugins install clawhub:spraay-batch`
- **Security**: Pass (SkillSpector)
- **Category**: Payments / DeFi / Agent treasury