### PR TITLE
Add Open Index to ecosystem resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Each plugin follows the standard OpenClaw plugin structure (`openclaw.plugin.jso
 - [vincentkoc/awesome-openclaw](https://github.com/vincentkoc/awesome-openclaw) — Another community-curated list
 - [VoltAgent/awesome-openclaw-skills](https://github.com/VoltAgent/awesome-openclaw-skills) — Skills-focused list
 - [SamurAIGPT/awesome-openclaw](https://github.com/SamurAIGPT/awesome-openclaw) — Broader ecosystem list
+- [Open Index](https://github.com/DrDroidLab/open-index) — Structured context graphs and an MCP server for domain-specific agents, with a portable OpenClaw setup skill
 
 ---
 


### PR DESCRIPTION
## Summary

Add Open Index to Resources as a structured context graph and MCP server with a portable OpenClaw setup skill.

Open Index is listed as a resource rather than a community plugin because it does not claim a native openclaw.plugin.json integration.

Project: https://github.com/DrDroidLab/open-index