### PR TITLE
docs: add Univer Office for OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Each plugin follows the standard OpenClaw plugin structure (`openclaw.plugin.jso
 | Plugin | Author | Stars | Description |
 |--------|--------|-------|-------------|
 | [@composio/openclaw-plugin](https://www.npmjs.com/package/@composio/openclaw-plugin) | Composio | — | Access 1000+ third-party tools (Gmail, Slack, GitHub, Notion, Linear, Jira, HubSpot, Salesforce, Google Drive, etc.) via Composio's MCP server. Single plugin, one API key. |
+| [Univer Office for OpenClaw](https://github.com/dream-num/openclaw-univer-office) | dream-num | — | Gives OpenClaw agents a collaborative Univer Workspace for spreadsheets, documents, slides, boards, PDFs, and relational tables, with review worktrees and self-hosted deployment. |
 
 ## Other Notable Plugins
 


### PR DESCRIPTION
## Summary

Adds Univer Office for OpenClaw to the Tool Integrations section.

The Apache-2.0 plugin connects OpenClaw to a collaborative Univer Workspace for spreadsheets, documents, slides, boards, PDFs, and relational tables. It supports review worktrees, self-hosted deployment, real-time collaboration, and import/export workflows.

## Verification

- Public repository and working README
- Valid `openclaw.plugin.json` manifest
- Installable from ClawHub as `@dr-univer/openclaw-univer-office`
- Public screenshots and demo video are included in the project README

Disclosure: I am affiliated with the project.